### PR TITLE
backport base64url for latest nodejs lts 14.16.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x, 15.x, 16.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 15.x
+          node-version: 14.x
       - run: npm install
       - run: npm test

--- a/lib/generate-qr-code-url.js
+++ b/lib/generate-qr-code-url.js
@@ -1,6 +1,6 @@
 'use strict'
 
 module.exports = async (buffer) => {
-  const asBase64url = buffer.toString('base64url')
+  const asBase64url = buffer.toString('base64').replace(/\+/g,"-").replace(/\//g,"_").replace(/=/g, "");
   return `https://e.coronawarn.app/?v=1#${asBase64url}`
 }

--- a/lib/generate-qr-code-url.js
+++ b/lib/generate-qr-code-url.js
@@ -1,6 +1,9 @@
 'use strict'
 
 module.exports = async (buffer) => {
-  const asBase64url = buffer.toString('base64').replace(/\+/g,"-").replace(/\//g,"_").replace(/=/g, "");
+  const asBase64url = buffer.toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
   return `https://e.coronawarn.app/?v=1#${asBase64url}`
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "standard": "16.0.3"
   },
   "engines": {
-    "node": ">=15"
+    "node": ">=14"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
generate base64url encoding manually to allow latest nodejs lts version to be supported.

This seems to be the only change necessary to backport the solution to nodejs 14.16.1 which is the latest LTS version.
LTS are often the only supported versions.