### PR TITLE
make options optional for SVG & PNG creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 15.x
+          node-version: 14.x
       - run: npm install
       - run: npm test

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,12 +46,14 @@ const createEventQRCode = ({ locationData, vendorData }) => {
     return qrCodeToBuffer(url, options)
   }
   const toPNG = async (filepath, options) => {
-    options.type = 'png'
-    return toFile(filepath, options)
+    const optionsParam = options || {};
+    optionsParam.type = 'png'
+    return toFile(filepath, optionsParam)
   }
   const toSVG = async (filepath, options) => {
-    options.type = 'svg'
-    return toFile(filepath, options)
+    const optionsParam = options || {};
+    optionsParam.type = 'svg'
+    return toFile(filepath, optionsParam)
   }
   const toString = async () => {
     const url = await toURL()

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,23 +37,21 @@ const createEventQRCode = ({ locationData, vendorData }) => {
     const url = generateQRCodeUrl(buffer)
     return url
   }
-  const toFile = async (filepath, options) => {
+  const toFile = async (filepath, options = {}) => {
     const url = await toURL()
     return qrCodeToFile(filepath, url, options)
   }
-  const toBuffer = async (options) => {
+  const toBuffer = async (options = {}) => {
     const url = await toURL()
     return qrCodeToBuffer(url, options)
   }
-  const toPNG = async (filepath, options) => {
-    const optionsParam = options || {};
-    optionsParam.type = 'png'
-    return toFile(filepath, optionsParam)
+  const toPNG = async (filepath, options = {}) => {
+    options.type = 'png'
+    return toFile(filepath, options)
   }
-  const toSVG = async (filepath, options) => {
-    const optionsParam = options || {};
-    optionsParam.type = 'svg'
-    return toFile(filepath, optionsParam)
+  const toSVG = async (filepath, options = {}) => {
+    options.type = 'svg'
+    return toFile(filepath, options)
   }
   const toString = async () => {
     const url = await toURL()


### PR DESCRIPTION
The options param is optional and not mentioned in the documentation when calling the function from nodejs. hence it's made optional here as well.
Same should also apply for SVG.