### PR TITLE
Add reference to guide on coronawarn.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Remark: This utility is in early stages of development and should help you to cr
 
 You need version 14 (LTS) or higher of [Node.js](https://nodejs.org/en/) (which includes npm) to use this utility.
 
+## Usage Guide
+
+A step by step explanation on how to use this tool is available [here](https://coronawarn.app/en/event-qr-code-guide/), on our website.
+
 ## CLI Usage
 
 #### Installation and Basics


### PR DESCRIPTION
### This PR has to be merged AFTER https://github.com/corona-warn-app/cwa-website/pull/1641! 

This PR adds a reference to the explanation on how to use this tool on coronawarn.app.

Screenshot: 
![New Section in README](https://user-images.githubusercontent.com/67682506/129934903-e6fe9e5b-42f3-45ba-ac31-138bacb0bc86.png)

