### PR TITLE
Replace whitespaces to prevent crashing qr code generation

### DIFF
--- a/lib/read-qr-code-data-from-csv.js
+++ b/lib/read-qr-code-data-from-csv.js
@@ -28,8 +28,8 @@ module.exports = async filepath => {
           }
           const { filepath } = data
           const locationData = {
-            description: data.description,
-            address: data.address,
+            description: data.description.replace(/\s+/g, ' '),
+            address: data.address.replace(/\s+/g, ' '),
             startTimestamp: parseInt(new Date(data.startdate).getTime() / 1000),
             endTimestamp: parseInt(new Date(data.enddate).getTime() / 1000)
           }


### PR DESCRIPTION
Regards on Issue [Event QR code generator: replace newlines by whitespace #2495](https://github.com/corona-warn-app/cwa-website/issues/2495) i made a little change to **read-qr-code-data-from-csv.js**

All whitespace characters in the **description** and **address** field are replaces with a single space to prevent crashing qr code generation. Based on the Helvetica Font only Windows-1252 encoding is allowed. So newlines, tabs etc. are not allowed.


---
Internal Tracking ID: [EXPOSUREAPP-12078)](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12078)
